### PR TITLE
fix(admin): drop session player_name after token reset

### DIFF
--- a/cmd/id-100/admin_handlers.go
+++ b/cmd/id-100/admin_handlers.go
@@ -375,6 +375,15 @@ func tokenMiddlewareWithSession(next echo.HandlerFunc) echo.HandlerFunc {
 
 		session.Save(c.Request(), c.Response())
 
+		// If DB currently has no current_player (e.g. after an admin reset), remove any stored player_name from the session
+		if currentPlayer == "" {
+			if _, ok := session.Values["player_name"].(string); ok {
+				delete(session.Values, "player_name")
+				// persist session changes
+				session.Save(c.Request(), c.Response())
+			}
+		}
+
 		// Check if player name is set (first-time user flow)
 		if currentPlayer == "" {
 			// If this is a POST to /upload/set-name, let the handler process it


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session data cleanup to properly remove stale player information when no active player is detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->