### PR TITLE
feat: add leaderboard ranking feature

### DIFF
--- a/internal/handlers/app/derive.go
+++ b/internal/handlers/app/derive.go
@@ -98,6 +98,13 @@ func DerivenHandler(c echo.Context) error {
 		pages = append(pages, models.PageNumber{Number: totalPages, IsCurrent: page == totalPages})
 	}
 
+	// Fetch leaderboard (top 10 players)
+	leaderboard, err := repository.GetLeaderboard(context.Background(), 10)
+	if err != nil {
+		log.Printf("Leaderboard error: %v", err)
+		leaderboard = nil
+	}
+
 	// Generate SEO metadata
 	baseURL := seo.GetBaseURLFromRequest(c.Scheme(), c.Request().Host, c.Request().Header.Get("X-Forwarded-Host"))
 	builder := seo.NewBuilder(baseURL)
@@ -120,6 +127,7 @@ func DerivenHandler(c echo.Context) error {
 		"CurrentPath":     c.Request().URL.Path,
 		"CurrentYear":     time.Now().Year(),
 		"FooterStats":     stats,
+		"Leaderboard":     leaderboard,
 	}))
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -74,3 +74,12 @@ type PageNumber struct {
 	IsCurrent bool
 	IsDots    bool
 }
+
+// LeaderboardEntry represents a single entry in the player leaderboard
+type LeaderboardEntry struct {
+	Rank          int
+	PlayerName    string
+	PlayerCity    string
+	UniqueDerivens int
+	TotalPoints   int
+}

--- a/internal/repository/derive.go
+++ b/internal/repository/derive.go
@@ -314,6 +314,49 @@ func DecrementTokenUploadCount(ctx context.Context, tokenID int) error {
 	return err
 }
 
+// GetLeaderboard retrieves the top N players ordered by total points
+func GetLeaderboard(ctx context.Context, limit int) ([]models.LeaderboardEntry, error) {
+	rows, err := database.DB.Query(ctx, `
+		SELECT
+			player_name,
+			COALESCE(MAX(player_city), '') AS player_city,
+			COUNT(*) AS unique_derives,
+			COALESCE(SUM(derive_points), 0) AS total_points
+		FROM (
+			SELECT DISTINCT ON (ul.player_name, ul.derive_number)
+				ul.player_name,
+				ul.derive_number,
+				d.points AS derive_points,
+				COALESCE(c.user_city, '') AS player_city
+			FROM upload_logs ul
+			JOIN deriven d ON d.number = ul.derive_number
+			LEFT JOIN contributions c ON c.id = ul.contribution_id
+			WHERE ul.player_name IS NOT NULL AND ul.player_name != ''
+			ORDER BY ul.player_name, ul.derive_number, ul.uploaded_at DESC
+		) sub
+		GROUP BY player_name
+		ORDER BY total_points DESC NULLS LAST, unique_derives DESC
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []models.LeaderboardEntry
+	rank := 1
+	for rows.Next() {
+		var e models.LeaderboardEntry
+		if err := rows.Scan(&e.PlayerName, &e.PlayerCity, &e.UniqueDerivens, &e.TotalPoints); err != nil {
+			return nil, err
+		}
+		e.Rank = rank
+		rank++
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
 // Admin-specific database queries
 
 // GetAllTokens retrieves all upload tokens

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -2029,3 +2029,117 @@ button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ========================================
+   LEADERBOARD WIDGET
+   ======================================== */
+.leaderboard-widget {
+  margin-bottom: var(--pad-2xl);
+  background: var(--gray-50);
+  border-radius: var(--radius-md);
+  padding: var(--pad-lg);
+  border: var(--border-light);
+}
+
+.leaderboard-title {
+  font-size: 1rem;
+  font-weight: 400;
+  margin: 0 0 var(--gap-md) 0;
+  letter-spacing: var(--letter-spacing-tighter);
+  color: var(--gray-900);
+}
+
+.leaderboard-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.leaderboard-entry {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-md);
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  border: var(--border-light);
+  border-left: 3px solid transparent;
+  transition: transform var(--transition-fast);
+}
+
+.leaderboard-entry:hover {
+  transform: translateX(3px);
+}
+
+.leaderboard-entry.rank-1 { border-left-color: #f5c518; }
+.leaderboard-entry.rank-2 { border-left-color: #a8a9ad; }
+.leaderboard-entry.rank-3 { border-left-color: #cd7f32; }
+
+.leaderboard-rank {
+  width: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.leaderboard-flag {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
+.leaderboard-rank-num {
+  font-size: 0.82rem;
+  font-weight: 400;
+  color: var(--gray-600);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.leaderboard-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.leaderboard-name {
+  font-size: 0.9rem;
+  font-weight: 400;
+  letter-spacing: var(--letter-spacing-tight);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--gray-900);
+}
+
+.leaderboard-city {
+  font-size: 0.75rem;
+  color: var(--gray-600);
+  font-weight: 300;
+}
+
+.leaderboard-score {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-shrink: 0;
+  gap: 0.1rem;
+}
+
+.leaderboard-points {
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: var(--letter-spacing-tight);
+  color: var(--gray-900);
+}
+
+.leaderboard-uploads {
+  font-size: 0.72rem;
+  color: var(--gray-600);
+  font-weight: 300;
+}

--- a/web/templates/app/deriven.html
+++ b/web/templates/app/deriven.html
@@ -27,6 +27,37 @@
             </div>
             {{end}}
         </div>
+
+        {{if .Leaderboard}}
+        <div class="leaderboard-widget">
+            <h3 class="leaderboard-title">Bestenliste</h3>
+            <ol class="leaderboard-list">
+                {{range .Leaderboard}}
+                <li class="leaderboard-entry rank-{{.Rank}}">
+                    <div class="leaderboard-rank">
+                        {{if le .Rank 3}}
+                        <img
+                            src="/static/assets/images/ui/points_indicator_{{.Rank}}.png"
+                            alt="Platz {{.Rank}}"
+                            class="leaderboard-flag"
+                        >
+                        {{else}}
+                        <span class="leaderboard-rank-num">#{{.Rank}}</span>
+                        {{end}}
+                    </div>
+                    <div class="leaderboard-info">
+                        <span class="leaderboard-name">{{.PlayerName}}</span>
+                        {{if .PlayerCity}}<span class="leaderboard-city">{{.PlayerCity}}</span>{{end}}
+                    </div>
+                    <div class="leaderboard-score">
+                        <span class="leaderboard-points">{{.TotalPoints}} Pkt.</span>
+                        <span class="leaderboard-uploads">{{.UniqueDerivens}} IDs</span>
+                    </div>
+                </li>
+                {{end}}
+            </ol>
+        </div>
+        {{end}}
         
         <div class="id-grid">
             {{range .Deriven}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a leaderboard widget displaying the top 10 players ranked by total points and unique derivens.
  * Leaderboard entries show player name, city, ranking position, total points, and count of unique derivens.
  * Top 3 ranked players receive special visual highlighting with distinctive styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->