### PR TITLE
feat(favicon): add static 🆔 favicon as crawler/API fallback

### DIFF
--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y="80" font-size="80">🆔</text>
+  <text x="50" y="50" font-size="90" text-anchor="middle" dominant-baseline="central">🆔</text>
 </svg>

--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text x="50" y="50" font-size="90" text-anchor="middle" dominant-baseline="central">🆔</text>
+  <text x="50" y="82" font-size="88" text-anchor="middle">🆔</text>
 </svg>

--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y="80" font-size="80">💯</text>
+  <text y="80" font-size="80">🆔</text>
 </svg>

--- a/web/static/favicon.svg
+++ b/web/static/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y="80" font-size="80">💯</text>
+</svg>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -6,6 +6,8 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <title>{{ .Title }}</title>
 
+      <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+
       <!-- SEO Meta Tags -->
       {{ if .SEO }}
         <meta name="description" content="{{ .SEO.Description }}" />


### PR DESCRIPTION
## Summary

- Adds a static `web/static/favicon.svg` (🆔 emoji) and links it in the `<head>` so Google's favicon API and other crawlers find a real favicon
- Keeps the client-side random emoji pick (🏠, 🆔, 💯, 🚨) which overrides the static favicon on each page load in the browser
- Centers the emoji glyph in the viewBox to avoid whitespace on the right

## Why

Crawlers and the Google favicon API don't run the client JS, so they previously had no favicon to resolve. The static SVG gives them a consistent brand marker while users still get the dynamic random emoji.

## Test plan

- [x] `npx vitest run` — all 77 tests pass
- [ ] Verify `/static/favicon.svg` loads in the browser
- [ ] Confirm crawlers see 🆔 and browser tab shows a random pool emoji

https://claude.ai/code/session_01238kTWC8NnAZsm4VoRUKja