### PR TITLE
Add Traefik routing configuration for Meilisearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=coolify
+      - traefik.http.routers.meilisearch.rule=Host(`search.id-100.online`)
+      - traefik.http.routers.meilisearch.entrypoints=https
+      - traefik.http.routers.meilisearch.tls.certresolver=letsencrypt
+      - traefik.http.services.meilisearch.loadbalancer.server.port=7700
 
   geonames-loader:
     image: alpine:latest


### PR DESCRIPTION
## Summary
This change adds Traefik reverse proxy routing labels to the Meilisearch service in the Docker Compose configuration, enabling external access to the search service through a dedicated domain.

## Key Changes
- Added Traefik labels to the Meilisearch service to enable automatic routing configuration
- Configured the service to be accessible at `search.id-100.online` over HTTPS
- Set up TLS certificate resolution using Let's Encrypt
- Mapped the internal Meilisearch port (7700) for load balancing
- Connected the service to the `coolify` Docker network for Traefik integration

## Implementation Details
The Traefik configuration includes:
- `traefik.enable=true` - Enables Traefik routing for this service
- `traefik.docker.network=coolify` - Specifies the network Traefik should use to reach the service
- `traefik.http.routers.meilisearch.rule=Host(...)` - Routes requests to the specified domain
- `traefik.http.routers.meilisearch.entrypoints=https` - Enforces HTTPS-only access
- `traefik.http.routers.meilisearch.tls.certresolver=letsencrypt` - Automatically provisions and renews SSL certificates
- `traefik.http.services.meilisearch.loadbalancer.server.port=7700` - Directs traffic to Meilisearch's default port

https://claude.ai/code/session_01NMtsWKdsgJrgg9cF3ckrJd