### PR TITLE
Use Coolify SERVICE_FQDN magic vars for routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,3 @@
-# =============================================================================
-# PRODUCTION COMPOSE — managed by Coolify
-# -----------------------------------------------------------------------------
-# This file is deployed by Coolify, NOT meant for plain `docker compose up`.
-# Public routing (domains + TLS) is configured via Coolify's SERVICE_FQDN_*
-# magic environment variables; Coolify generates the proxy/Traefik labels and
-# Let's Encrypt certificates from them and exposes the URLs in its "Links" UI.
-#
-# Local development uses docker-compose.dev.yml instead.
-# Docs: https://coolify.io/docs/knowledge-base/docker/compose
-# =============================================================================
 services:
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_SERVER_URL: ${MINIO_SERVER_URL}
       MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL}
+      SERVICE_FQDN_MINIO_9000: https://s3.id-100.online
+      SERVICE_FQDN_MINIOCONSOLE_9001: https://oss.id-100.online
     volumes:
       - minio_data:/data
     healthcheck:
@@ -30,19 +32,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.minio-api.rule=Host(`s3.id-100.online`)
-      - traefik.http.routers.minio-api.entrypoints=https
-      - traefik.http.routers.minio-api.tls.certresolver=letsencrypt
-      - traefik.http.routers.minio-api.service=minio-api
-      - traefik.http.services.minio-api.loadbalancer.server.port=9000
-      - traefik.http.routers.minio-console.rule=Host(`oss.id-100.online`)
-      - traefik.http.routers.minio-console.entrypoints=https
-      - traefik.http.routers.minio-console.tls.certresolver=letsencrypt
-      - traefik.http.routers.minio-console.service=minio-console
-      - traefik.http.services.minio-console.loadbalancer.server.port=9001
 
   minio-init:
     image: minio/mc:latest
@@ -65,6 +54,7 @@ services:
       MEILI_ENV: ${ENVIRONMENT}
       MEILI_NO_ANALYTICS: ${MEILI_NO_ANALYTICS}
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
+      SERVICE_FQDN_MEILISEARCH_7700: https://search.id-100.online
     volumes:
       - meilisearch_data:/meili_data
     healthcheck:
@@ -72,13 +62,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.meilisearch.rule=Host(`search.id-100.online`)
-      - traefik.http.routers.meilisearch.entrypoints=https
-      - traefik.http.routers.meilisearch.tls.certresolver=letsencrypt
-      - traefik.http.services.meilisearch.loadbalancer.server.port=7700
 
   geonames-loader:
     image: alpine:latest
@@ -161,19 +144,13 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       UMAMI_SCRIPT_URL: ${UMAMI_SCRIPT_URL}
       UMAMI_WEBSITE_ID: ${UMAMI_WEBSITE_ID}
+      SERVICE_FQDN_WEBAPP_8080: https://id-100.online
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.webapp.rule=Host(`id-100.online`)
-      - traefik.http.routers.webapp.entrypoints=https
-      - traefik.http.routers.webapp.tls.certresolver=letsencrypt
-      - traefik.http.services.webapp.loadbalancer.server.port=8080
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,14 @@
+# =============================================================================
+# PRODUCTION COMPOSE — managed by Coolify
+# -----------------------------------------------------------------------------
+# This file is deployed by Coolify, NOT meant for plain `docker compose up`.
+# Public routing (domains + TLS) is configured via Coolify's SERVICE_FQDN_*
+# magic environment variables; Coolify generates the proxy/Traefik labels and
+# Let's Encrypt certificates from them and exposes the URLs in its "Links" UI.
+#
+# Local development uses docker-compose.dev.yml instead.
+# Docs: https://coolify.io/docs/knowledge-base/docker/compose
+# =============================================================================
 services:
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
## Was

Ersetzt die manuell geschriebenen Traefik-Labels durch Coolifys `SERVICE_FQDN_*` Magic Environment Variables für `webapp`, `minio` und `meilisearch`.

| Service | Magic-Var | Domain |
|---|---|---|
| `webapp` | `SERVICE_FQDN_WEBAPP_8080` | `id-100.online` |
| `minio` (API) | `SERVICE_FQDN_MINIO_9000` | `s3.id-100.online` |
| `minio` (Console) | `SERVICE_FQDN_MINIOCONSOLE_9001` | `oss.id-100.online` |
| `meilisearch` | `SERVICE_FQDN_MEILISEARCH_7700` | `search.id-100.online` |

## Warum

Coolify füllt das **Links-Dropdown** im UI aus den `SERVICE_FQDN_*`-Variablen. Mit den bisherigen handgeschriebenen Traefik-Labels kannte Coolify die Domains nicht selbst → keine Links. Jetzt generiert Coolify Routing + Let's-Encrypt-TLS selbst und zeigt alle vier URLs an. 27 Zeilen Boilerplate raus, 4 rein.

## Beim Deploy beachten

- Links erscheinen erst nach einem Re-Deploy.
- `.env`-Vars (`MINIO_SERVER_URL`, `MINIO_BROWSER_REDIRECT_URL`, `BASE_URL`) müssen weiterhin auf dieselben Domains zeigen.
- Sicherstellen, dass keine alten manuellen Domain-Einträge in den Coolify-Service-Feldern mit den Magic-Vars kollidieren.

https://claude.ai/code/session_01Pto4tPLaBqTwuE2Hh11qd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pto4tPLaBqTwuE2Hh11qd5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose service configuration to use new environment variable format for service endpoints.
  * Simplified service routing configuration across MinIO, MeiliSearch, and Webapp services.
  * Healthcheck configurations remain in place for affected services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dmnktoe/id-100/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->