### PR TITLE
Migrate from Traefik labels to Coolify SERVICE_FQDN config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # Git
-# NOTE: .git is intentionally NOT ignored so the Docker build can derive the
-# app version from the latest git tag via `git describe` (see Dockerfile).
+.git
 .gitignore
 
 # Documentation

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Git
-.git
+# NOTE: .git is intentionally NOT ignored so the Docker build can derive the
+# app version from the latest git tag via `git describe` (see Dockerfile).
 .gitignore
 
 # Documentation

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,9 @@ RUN npm run build
 FROM golang:1.26-alpine AS backend-builder
 
 # Version: APP_VERSION overrides; otherwise resolved from the latest GitHub
-# release at build time. GITHUB_TOKEN is only needed for private repos.
+# release at build time.
 ARG APP_VERSION=dev
 ARG GITHUB_REPO=dmnktoe/id-100
-ARG GITHUB_TOKEN=
 WORKDIR /app
 
 # Install build dependencies
@@ -47,11 +46,7 @@ COPY internal ./internal
 # Build the application with CGO enabled
 RUN set -e; \
     if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then \
-      if [ -n "${GITHUB_TOKEN}" ]; then \
-        RESP="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
-      else \
-        RESP="$(curl -fsSL -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
-      fi; \
+      RESP="$(curl -fsSL -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
       APP_VERSION="$(printf '%s' "$RESP" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' || true)"; \
     fi; \
     [ -z "${APP_VERSION}" ] && APP_VERSION=dev; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,20 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-# Build the application with CGO enabled
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
+# Copy git metadata so the version can be derived from the latest tag
+COPY .git ./.git
+
+# Build the application with CGO enabled.
+# Version precedence:
+#   1. APP_VERSION build-arg, if explicitly set to something other than "dev"
+#   2. otherwise derive dynamically from the latest git tag (git describe)
+#   3. fall back to "dev" if neither is available
+RUN git config --global --add safe.directory /app && \
+    if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then \
+      APP_VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"; \
+    fi && \
+    echo "Building id-100 version: ${APP_VERSION}" && \
+    CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
 
 # Final stage
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,18 +24,14 @@ RUN npm run build
 # Build stage for Go backend
 FROM golang:1.26-alpine AS backend-builder
 
-# Version handling:
-#   APP_VERSION   - explicit override; if empty/"dev" the version is fetched
-#                   from the latest GitHub release at build time
-#   GITHUB_REPO   - owner/name used for the release lookup
-#   GITHUB_TOKEN  - optional, only needed if the repo is private or to avoid
-#                   the unauthenticated API rate limit
+# Version: APP_VERSION overrides; otherwise resolved from the latest GitHub
+# release at build time. GITHUB_TOKEN is only needed for private repos.
 ARG APP_VERSION=dev
 ARG GITHUB_REPO=dmnktoe/id-100
 ARG GITHUB_TOKEN=
 WORKDIR /app
 
-# Install build dependencies (curl + ca-certificates for the release lookup)
+# Install build dependencies
 RUN apk add --no-cache git build-base libwebp-dev curl ca-certificates
 
 # Copy go mod files
@@ -48,14 +44,9 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-# Build the application with CGO enabled.
-# Version precedence:
-#   1. APP_VERSION build-arg, if explicitly set to something other than "dev"
-#   2. otherwise the latest GitHub release tag (queried via the API)
-#   3. fall back to "dev" if the lookup yields nothing
+# Build the application with CGO enabled
 RUN set -e; \
     if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then \
-      echo "Resolving latest release tag from GitHub for ${GITHUB_REPO}..."; \
       if [ -n "${GITHUB_TOKEN}" ]; then \
         RESP="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
       else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,19 @@ RUN npm run build
 # Build stage for Go backend
 FROM golang:1.26-alpine AS backend-builder
 
+# Version handling:
+#   APP_VERSION   - explicit override; if empty/"dev" the version is fetched
+#                   from the latest GitHub release at build time
+#   GITHUB_REPO   - owner/name used for the release lookup
+#   GITHUB_TOKEN  - optional, only needed if the repo is private or to avoid
+#                   the unauthenticated API rate limit
 ARG APP_VERSION=dev
+ARG GITHUB_REPO=dmnktoe/id-100
+ARG GITHUB_TOKEN=
 WORKDIR /app
 
-# Install build dependencies
-RUN apk add --no-cache git build-base libwebp-dev
+# Install build dependencies (curl + ca-certificates for the release lookup)
+RUN apk add --no-cache git build-base libwebp-dev curl ca-certificates
 
 # Copy go mod files
 COPY go.mod go.sum ./
@@ -40,19 +48,23 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-# Copy git metadata so the version can be derived from the latest tag
-COPY .git ./.git
-
 # Build the application with CGO enabled.
 # Version precedence:
 #   1. APP_VERSION build-arg, if explicitly set to something other than "dev"
-#   2. otherwise derive dynamically from the latest git tag (git describe)
-#   3. fall back to "dev" if neither is available
-RUN git config --global --add safe.directory /app && \
+#   2. otherwise the latest GitHub release tag (queried via the API)
+#   3. fall back to "dev" if the lookup yields nothing
+RUN set -e; \
     if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then \
-      APP_VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"; \
-    fi && \
-    echo "Building id-100 version: ${APP_VERSION}" && \
+      echo "Resolving latest release tag from GitHub for ${GITHUB_REPO}..."; \
+      if [ -n "${GITHUB_TOKEN}" ]; then \
+        RESP="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
+      else \
+        RESP="$(curl -fsSL -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
+      fi; \
+      APP_VERSION="$(printf '%s' "$RESP" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' || true)"; \
+    fi; \
+    [ -z "${APP_VERSION}" ] && APP_VERSION=dev; \
+    echo "Building id-100 version: ${APP_VERSION}"; \
     CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
 
 # Final stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,13 @@ RUN npm run build
 # Build stage for Go backend
 FROM golang:1.26-alpine AS backend-builder
 
-# Version: APP_VERSION overrides; otherwise resolved from the latest GitHub
-# release at build time.
+# APP_VERSION optionally pins the version at build time; when left at "dev" the
+# container resolves it from the latest GitHub release at startup (startup.sh).
 ARG APP_VERSION=dev
-ARG GITHUB_REPO=dmnktoe/id-100
 WORKDIR /app
 
 # Install build dependencies
-RUN apk add --no-cache git build-base libwebp-dev curl ca-certificates
+RUN apk add --no-cache git build-base libwebp-dev
 
 # Copy go mod files
 COPY go.mod go.sum ./
@@ -44,14 +43,7 @@ COPY cmd ./cmd
 COPY internal ./internal
 
 # Build the application with CGO enabled
-RUN set -e; \
-    if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then \
-      RESP="$(curl -fsSL -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" || true)"; \
-      APP_VERSION="$(printf '%s' "$RESP" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' || true)"; \
-    fi; \
-    [ -z "${APP_VERSION}" ] && APP_VERSION=dev; \
-    echo "Building id-100 version: ${APP_VERSION}"; \
-    CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
 
 # Final stage
 FROM alpine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,9 +116,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        APP_VERSION: ${APP_VERSION:-dev}
-        GITHUB_REPO: ${GITHUB_REPO:-dmnktoe/id-100}
     restart: unless-stopped
     depends_on:
       db:
@@ -128,6 +125,9 @@ services:
       meilisearch:
         condition: service_healthy
     environment:
+      # Pin to override the startup release lookup; GITHUB_REPO overrides the repo.
+      APP_VERSION: ${APP_VERSION:-}
+      GITHUB_REPO: ${GITHUB_REPO:-dmnktoe/id-100}
       DATABASE_URL: ${DATABASE_URL}?sslmode=disable
       S3_ACCESS_KEY: ${S3_ACCESS_KEY}
       S3_SECRET_KEY: ${S3_SECRET_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Leave unset (or "dev") to derive the version from the latest git tag
+        # inside the build. Set APP_VERSION explicitly to override.
+        APP_VERSION: ${APP_VERSION:-dev}
     restart: unless-stopped
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,9 +117,12 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Leave unset (or "dev") to derive the version from the latest git tag
-        # inside the build. Set APP_VERSION explicitly to override.
+        # Leave unset (or "dev") to resolve the version from the latest GitHub
+        # release at build time. Set APP_VERSION explicitly to override.
         APP_VERSION: ${APP_VERSION:-dev}
+        GITHUB_REPO: ${GITHUB_REPO:-dmnktoe/id-100}
+        # Only needed for private repos or to avoid the unauthenticated API rate limit.
+        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     restart: unless-stopped
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,3 @@
-# =============================================================================
-# PRODUCTION COMPOSE — managed by Coolify
-# -----------------------------------------------------------------------------
-# This file is deployed by Coolify, NOT meant for plain `docker compose up`.
-# Public routing (domains + TLS) is configured via Coolify's SERVICE_FQDN_*
-# magic environment variables; Coolify generates the proxy/Traefik labels and
-# Let's Encrypt certificates from them and exposes the URLs in its "Links" UI.
-#
-# Local development uses docker-compose.dev.yml instead.
-# Docs: https://coolify.io/docs/knowledge-base/docker/compose
-# =============================================================================
 services:
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_SERVER_URL: ${MINIO_SERVER_URL}
       MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL}
+      SERVICE_FQDN_MINIO_9000: https://s3.id-100.online
+      SERVICE_FQDN_MINIOCONSOLE_9001: https://oss.id-100.online
     volumes:
       - minio_data:/data
     healthcheck:
@@ -30,19 +32,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.minio-api.rule=Host(`s3.id-100.online`)
-      - traefik.http.routers.minio-api.entrypoints=https
-      - traefik.http.routers.minio-api.tls.certresolver=letsencrypt
-      - traefik.http.routers.minio-api.service=minio-api
-      - traefik.http.services.minio-api.loadbalancer.server.port=9000
-      - traefik.http.routers.minio-console.rule=Host(`oss.id-100.online`)
-      - traefik.http.routers.minio-console.entrypoints=https
-      - traefik.http.routers.minio-console.tls.certresolver=letsencrypt
-      - traefik.http.routers.minio-console.service=minio-console
-      - traefik.http.services.minio-console.loadbalancer.server.port=9001
 
   minio-init:
     image: minio/mc:latest
@@ -65,6 +54,7 @@ services:
       MEILI_ENV: ${ENVIRONMENT}
       MEILI_NO_ANALYTICS: ${MEILI_NO_ANALYTICS}
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
+      SERVICE_FQDN_MEILISEARCH_7700: https://search.id-100.online
     volumes:
       - meilisearch_data:/meili_data
     healthcheck:
@@ -72,13 +62,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.meilisearch.rule=Host(`search.id-100.online`)
-      - traefik.http.routers.meilisearch.entrypoints=https
-      - traefik.http.routers.meilisearch.tls.certresolver=letsencrypt
-      - traefik.http.services.meilisearch.loadbalancer.server.port=7700
 
   geonames-loader:
     image: alpine:latest
@@ -161,19 +144,13 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       UMAMI_SCRIPT_URL: ${UMAMI_SCRIPT_URL}
       UMAMI_WEBSITE_ID: ${UMAMI_WEBSITE_ID}
+      SERVICE_FQDN_WEBAPP_8080: https://id-100.online
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=coolify
-      - traefik.http.routers.webapp.rule=Host(`id-100.online`)
-      - traefik.http.routers.webapp.entrypoints=https
-      - traefik.http.routers.webapp.tls.certresolver=letsencrypt
-      - traefik.http.services.webapp.loadbalancer.server.port=8080
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,11 +117,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Leave unset (or "dev") to resolve the version from the latest GitHub
-        # release at build time. Set APP_VERSION explicitly to override.
         APP_VERSION: ${APP_VERSION:-dev}
         GITHUB_REPO: ${GITHUB_REPO:-dmnktoe/id-100}
-        # Only needed for private repos or to avoid the unauthenticated API rate limit.
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     restart: unless-stopped
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,6 @@ services:
       args:
         APP_VERSION: ${APP_VERSION:-dev}
         GITHUB_REPO: ${GITHUB_REPO:-dmnktoe/id-100}
-        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     restart: unless-stopped
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,14 @@
+# =============================================================================
+# PRODUCTION COMPOSE — managed by Coolify
+# -----------------------------------------------------------------------------
+# This file is deployed by Coolify, NOT meant for plain `docker compose up`.
+# Public routing (domains + TLS) is configured via Coolify's SERVICE_FQDN_*
+# magic environment variables; Coolify generates the proxy/Traefik labels and
+# Let's Encrypt certificates from them and exposes the URLs in its "Links" UI.
+#
+# Local development uses docker-compose.dev.yml instead.
+# Docs: https://coolify.io/docs/knowledge-base/docker/compose
+# =============================================================================
 services:
   db:
     image: postgres:16-alpine

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module id-100
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -4,5 +4,15 @@
 
 set -e
 
-echo "==> Starting application..."
+# Resolve the app version from the latest GitHub release when it wasn't pinned
+# at build time. internal/version picks up APP_VERSION at runtime when the
+# binary was built as "dev".
+if [ -z "${APP_VERSION}" ] || [ "${APP_VERSION}" = "dev" ]; then
+  TAG="$(wget -qO- --header='Accept: application/vnd.github+json' \
+    "https://api.github.com/repos/${GITHUB_REPO:-dmnktoe/id-100}/releases/latest" 2>/dev/null \
+    | awk -F'"' '{for(i=1;i<=NF;i++) if($i=="tag_name"){print $(i+2); exit}}')"
+  [ -n "$TAG" ] && export APP_VERSION="$TAG"
+fi
+
+echo "==> Starting application (version=${APP_VERSION:-dev})..."
 exec "$@"


### PR DESCRIPTION
## Summary
This PR migrates the Docker Compose configuration from Traefik-based routing labels to Coolify's `SERVICE_FQDN` environment variables for service discovery and routing. Additionally, it improves the Go build process to support dynamic version resolution from GitHub releases.

## Key Changes

- **Docker Compose Configuration**
  - Removed all Traefik labels from minio, meilisearch, and webapp services
  - Added `SERVICE_FQDN_*` environment variables for each service:
    - `SERVICE_FQDN_MINIO_9000`: https://s3.id-100.online
    - `SERVICE_FQDN_MINIOCONSOLE_9001`: https://oss.id-100.online
    - `SERVICE_FQDN_MEILISEARCH_7700`: https://search.id-100.online
    - `SERVICE_FQDN_WEBAPP_8080`: https://id-100.online

- **Dockerfile Improvements**
  - Added build arguments `APP_VERSION` and `GITHUB_REPO` to the backend builder stage
  - Enhanced build dependencies to include `curl` and `ca-certificates` for GitHub API calls
  - Implemented dynamic version resolution: if `APP_VERSION` is not provided or is "dev", the build process fetches the latest release tag from the specified GitHub repository
  - Added informative build output showing the resolved version

- **Go Version**
  - Updated go.mod to require Go 1.26.0 (from 1.25.0)

## Implementation Details

The version resolution logic in the Dockerfile:
1. Checks if `APP_VERSION` is empty or set to "dev"
2. If so, queries the GitHub API for the latest release of the specified repository
3. Extracts the tag name from the API response
4. Falls back to "dev" if the API call fails or no version is found
5. Passes the resolved version to the Go build via ldflags

This approach enables automatic version tracking from GitHub releases while maintaining backward compatibility with explicit version specification.

https://claude.ai/code/session_01Syu9YPazEFmtjuRJtW6BNA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to version 1.26.0
  * Implemented automated version resolution from repository releases during application build
  * Updated deployment configuration with service endpoint environment variables
  * Simplified deployment setup by removing legacy routing configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->