### PR TITLE
fix: dynamic footer version, Go 1.26 alignment, restore Traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_SERVER_URL: ${MINIO_SERVER_URL}
       MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL}
-      SERVICE_FQDN_MINIO_9000: https://s3.id-100.online
-      SERVICE_FQDN_MINIOCONSOLE_9001: https://oss.id-100.online
     volumes:
       - minio_data:/data
     healthcheck:
@@ -32,6 +30,19 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=coolify
+      - traefik.http.routers.minio-api.rule=Host(`s3.id-100.online`)
+      - traefik.http.routers.minio-api.entrypoints=https
+      - traefik.http.routers.minio-api.tls.certresolver=letsencrypt
+      - traefik.http.routers.minio-api.service=minio-api
+      - traefik.http.services.minio-api.loadbalancer.server.port=9000
+      - traefik.http.routers.minio-console.rule=Host(`oss.id-100.online`)
+      - traefik.http.routers.minio-console.entrypoints=https
+      - traefik.http.routers.minio-console.tls.certresolver=letsencrypt
+      - traefik.http.routers.minio-console.service=minio-console
+      - traefik.http.services.minio-console.loadbalancer.server.port=9001
 
   minio-init:
     image: minio/mc:latest
@@ -54,7 +65,6 @@ services:
       MEILI_ENV: ${ENVIRONMENT}
       MEILI_NO_ANALYTICS: ${MEILI_NO_ANALYTICS}
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
-      SERVICE_FQDN_MEILISEARCH_7700: https://search.id-100.online
     volumes:
       - meilisearch_data:/meili_data
     healthcheck:
@@ -62,6 +72,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=coolify
+      - traefik.http.routers.meilisearch.rule=Host(`search.id-100.online`)
+      - traefik.http.routers.meilisearch.entrypoints=https
+      - traefik.http.routers.meilisearch.tls.certresolver=letsencrypt
+      - traefik.http.services.meilisearch.loadbalancer.server.port=7700
 
   geonames-loader:
     image: alpine:latest
@@ -147,13 +164,19 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       UMAMI_SCRIPT_URL: ${UMAMI_SCRIPT_URL}
       UMAMI_WEBSITE_ID: ${UMAMI_WEBSITE_ID}
-      SERVICE_FQDN_WEBAPP_8080: https://id-100.online
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=coolify
+      - traefik.http.routers.webapp.rule=Host(`id-100.online`)
+      - traefik.http.routers.webapp.entrypoints=https
+      - traefik.http.routers.webapp.tls.certresolver=letsencrypt
+      - traefik.http.services.webapp.loadbalancer.server.port=8080
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Why

After the Coolify migration the footer showed `vdev`: Coolify builds via `docker compose build`, which never injected a version, so `internal/version.Version` stayed at its `dev` default.

## Changes

**Footer version (vdev fix)**
- Resolve the version from the latest GitHub release at container startup in `scripts/startup.sh` (uses `wget` + `ca-certificates` already in the image). `internal/version` picks up `APP_VERSION` at runtime when the binary was built as `dev`, so the version is always current per container start.
- `APP_VERSION` / `GITHUB_REPO` exposed as runtime env overrides on the `webapp` service.
- Doing this at runtime (instead of build time) avoids stale versions from cached Docker layers and wires the runtime fallback — addressing the earlier CodeRabbit review.

**Go version alignment**
- `go.mod` bumped `1.25.0` → `1.26.0` to match the Dockerfile (`golang:1.26-alpine`) and CI (`go-version: "1.26"`).

**Routing**
- Restored explicit Traefik labels for `minio` (`s3.id-100.online:9000`), minio console (`oss.id-100.online:9001`), `meilisearch` (`search.id-100.online:7700`) and `webapp` (`id-100.online:8080`).
- Dropped the `SERVICE_FQDN_*` magic vars: Coolify generated colliding sslip.io domains (same host for all services, wrong ports) and ignored the predefined domains (coollabsio/coolify#6124).

Also folds in the Coolify routing commits from `keen-mendel`.

https://claude.ai/code/session_01Syu9YPazEFmtjuRJtW6BNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Syu9YPazEFmtjuRJtW6BNA)_