### PR TITLE
fix(version): handle empty embedded version so footer renders the real tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,11 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-# Build the application with CGO enabled
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
+# Build the application with CGO enabled.
+# Coalesce an empty APP_VERSION (e.g. injected as an empty build-arg) to "dev"
+# so the runtime startup lookup can resolve the real version.
+RUN APP_VERSION="${APP_VERSION:-dev}"; \
+    CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
 
 # Final stage
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,7 @@ RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 
-# Build the application with CGO enabled.
-# Coalesce an empty APP_VERSION (e.g. injected as an empty build-arg) to "dev"
-# so the runtime startup lookup can resolve the real version.
+# Build the application with CGO enabled
 RUN APP_VERSION="${APP_VERSION:-dev}"; \
     CGO_ENABLED=1 GOOS=linux go build -ldflags "-X 'id-100/internal/version.Version=${APP_VERSION}'" -o /app/bin/id-100 ./cmd/id-100
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,8 +8,7 @@ import "os"
 var Version = "dev"
 
 func init() {
-	// An empty Version can happen when the build passes an empty APP_VERSION
-	// build-arg; treat it the same as the "dev" default.
+	// An empty Version (empty build-arg) is treated like the "dev" default.
 	if Version == "" || Version == "dev" {
 		if v := os.Getenv("APP_VERSION"); v != "" {
 			Version = v

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,9 +8,14 @@ import "os"
 var Version = "dev"
 
 func init() {
-	if Version == "dev" {
+	// An empty Version can happen when the build passes an empty APP_VERSION
+	// build-arg; treat it the same as the "dev" default.
+	if Version == "" || Version == "dev" {
 		if v := os.Getenv("APP_VERSION"); v != "" {
 			Version = v
 		}
+	}
+	if Version == "" {
+		Version = "dev"
 	}
 }


### PR DESCRIPTION
## Why

Follow-up to #201 (already merged). In production the footer rendered blank and Sentry `release` was empty, even though `startup.sh` correctly resolved `version=1.2.2`.

Root cause: Coolify injects an **empty** `APP_VERSION` build-arg, so the binary was built with `Version=""` instead of `"dev"`. The runtime fallback only triggered on `"dev"`, so the startup-resolved tag was never applied.

## Changes

- `internal/version/version.go`: treat an empty embedded `Version` like the `dev` default for the runtime `APP_VERSION` override, and never leave it empty.
- `Dockerfile`: coalesce an empty `APP_VERSION` build-arg to `dev` so the runtime lookup stays reachable.

An explicit build-time pin still wins. Verified across all cases: empty build + runtime tag → tag; `dev` + tag → tag; empty + empty → `dev`; pin + tag → pin.

https://claude.ai/code/session_01Syu9YPazEFmtjuRJtW6BNA