### PR TITLE
fix: remove blur-up white flash and harden drawer event handlers

### DIFF
--- a/src/__tests__/drawer.test.ts
+++ b/src/__tests__/drawer.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for drawer module
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { initDrawer } from "../lib/drawer";
+
+const PARTIAL_HTML = '<button class="drawer-close">close</button>';
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+function setupDom(extra = ""): HTMLElement {
+  document.body.innerHTML = `
+    <div id="drawer-backdrop" aria-hidden="true"></div>
+    <div id="drawer-panel" aria-hidden="true"></div>
+    ${extra}
+  `;
+  return document.getElementById("drawer-panel") as HTMLElement;
+}
+
+describe("initDrawer", () => {
+  // initDrawer attaches listeners to document/window; capture them so each test
+  // starts from a clean slate instead of accumulating handlers across tests.
+  let docListeners: Array<[string, EventListenerOrEventListenerObject, unknown]>;
+  let winListeners: Array<[string, EventListenerOrEventListenerObject, unknown]>;
+
+  beforeEach(() => {
+    docListeners = [];
+    winListeners = [];
+
+    const realDocAdd = document.addEventListener.bind(document);
+    const realWinAdd = window.addEventListener.bind(window);
+    vi.spyOn(document, "addEventListener").mockImplementation((type, handler, opts) => {
+      docListeners.push([type as string, handler as EventListenerOrEventListenerObject, opts]);
+      return realDocAdd(type as never, handler as never, opts as never);
+    });
+    vi.spyOn(window, "addEventListener").mockImplementation((type, handler, opts) => {
+      winListeners.push([type as string, handler as EventListenerOrEventListenerObject, opts]);
+      return realWinAdd(type as never, handler as never, opts as never);
+    });
+
+    vi.spyOn(history, "back").mockImplementation(() => {});
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(PARTIAL_HTML),
+    });
+  });
+
+  afterEach(() => {
+    docListeners.forEach(([t, h, o]) => document.removeEventListener(t, h, o as never));
+    winListeners.forEach(([t, h, o]) => window.removeEventListener(t, h, o as never));
+    vi.restoreAllMocks();
+    document.body.className = "";
+    document.body.innerHTML = "";
+  });
+
+  it("does nothing when panel or backdrop are missing", () => {
+    document.body.innerHTML = `<div id="drawer-panel"></div>`; // backdrop missing
+
+    expect(() => initDrawer()).not.toThrow();
+    expect(docListeners).toHaveLength(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when prefetch fires with a non-Element target", () => {
+    // Regression: pointerenter in the capture phase can have e.target === document,
+    // which has no closest() — guard must short-circuit instead of throwing.
+    setupDom();
+    initDrawer();
+
+    expect(() => document.dispatchEvent(new Event("pointerenter"))).not.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when a click target is not an Element", () => {
+    setupDom();
+    initDrawer();
+
+    expect(() => document.dispatchEvent(new Event("click"))).not.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("opens the drawer when an id card is clicked", async () => {
+    const panel = setupDom(
+      `<div class="id-grid"><a href="/id/42?page=2" class="id-card">card</a></div>`
+    );
+    initDrawer();
+
+    const card = document.querySelector(".id-card") as HTMLElement;
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flush();
+
+    expect(fetch).toHaveBeenCalledWith("/id/42?partial=1&page=2");
+    expect(document.body.classList.contains("drawer-open")).toBe(true);
+    expect(panel.innerHTML).toContain("drawer-close");
+  });
+
+  it("reuses a hover prefetch for the subsequent click (dedupe)", async () => {
+    setupDom(`<div class="id-grid"><a href="/id/7" class="id-card">card</a></div>`);
+    initDrawer();
+
+    const card = document.querySelector(".id-card") as HTMLElement;
+    card.dispatchEvent(new Event("pointerenter"));
+    await flush();
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flush();
+
+    expect(document.body.classList.contains("drawer-open")).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("/id/7?partial=1");
+  });
+
+  it("opens a drawer-link as a partial without a card target", async () => {
+    setupDom(`<a href="/werkzeug" class="drawer-link">werkzeug anfordern</a>`);
+    initDrawer();
+
+    const link = document.querySelector(".drawer-link") as HTMLElement;
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flush();
+
+    expect(fetch).toHaveBeenCalledWith("/werkzeug?partial=1");
+    expect(document.body.classList.contains("drawer-open")).toBe(true);
+  });
+
+  it("closes an open drawer on Escape", async () => {
+    setupDom(`<div class="id-grid"><a href="/id/1" class="id-card">card</a></div>`);
+    initDrawer();
+
+    const card = document.querySelector(".id-card") as HTMLElement;
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flush();
+    expect(document.body.classList.contains("drawer-open")).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.body.classList.contains("drawer-open")).toBe(false);
+  });
+
+  it("closes the drawer when the backdrop is clicked", async () => {
+    setupDom(`<div class="id-grid"><a href="/id/1" class="id-card">card</a></div>`);
+    initDrawer();
+
+    const card = document.querySelector(".id-card") as HTMLElement;
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await flush();
+    expect(document.body.classList.contains("drawer-open")).toBe(true);
+
+    document.getElementById("drawer-backdrop")!.dispatchEvent(new MouseEvent("click"));
+    expect(document.body.classList.contains("drawer-open")).toBe(false);
+  });
+});

--- a/src/lib/drawer.ts
+++ b/src/lib/drawer.ts
@@ -151,7 +151,8 @@ export function initDrawer(): void {
 
   // prefetch on hover/touch for instant open (pointerenter doesn't bubble → capture)
   const prefetch = (e: Event): void => {
-    const card = (e.target as HTMLElement).closest<HTMLElement>(".id-card");
+    if (!(e.target instanceof Element)) return;
+    const card = e.target.closest<HTMLElement>(".id-card");
     const target = card && targetFromCard(card);
     if (target) fetchPartial(buildPartialUrl(target)).catch(() => {});
   };
@@ -160,7 +161,8 @@ export function initDrawer(): void {
 
   // open id cards in the drawer
   document.addEventListener("click", (e) => {
-    const card = (e.target as HTMLElement).closest<HTMLElement>(".id-card");
+    if (!(e.target instanceof Element)) return;
+    const card = e.target.closest<HTMLElement>(".id-card");
     if (!card) return;
     const target = targetFromCard(card);
     if (!target) return;
@@ -173,7 +175,8 @@ export function initDrawer(): void {
 
   // open simple drawer links (e.g. "werkzeug anfordern") without a history entry
   document.addEventListener("click", (e) => {
-    const link = (e.target as HTMLElement).closest<HTMLAnchorElement>(".drawer-link");
+    if (!(e.target instanceof Element)) return;
+    const link = e.target.closest<HTMLAnchorElement>(".drawer-link");
     if (!link) return;
     const href = link.getAttribute("href");
     if (!href) return;

--- a/src/lib/lazy-images.ts
+++ b/src/lib/lazy-images.ts
@@ -64,17 +64,45 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
     }
   });
 
+  // Preload the full-size image off-DOM and only swap the visible src once it
+  // is fully loaded (and decoded). Swapping src directly would discard the
+  // currently displayed LQIP and show a blank/white frame until the full image
+  // arrives — preloading keeps the blurred placeholder visible until the moment
+  // the sharp image is ready to paint.
+  const loadFull = (img: HTMLImageElement): void => {
+    const src = img.getAttribute("data-src");
+    if (!src || img.src === src || img.dataset.fullLoaded) return;
+    img.dataset.fullLoaded = "1";
+
+    const reveal = (): void => {
+      if (img.src !== src) img.src = src;
+      img.classList.add("loaded");
+    };
+
+    const pre = new Image();
+    pre.onload = (): void => {
+      // decode (when available) so the swap paints instantly without a flash
+      if (typeof pre.decode === "function") {
+        pre.decode().then(reveal).catch(reveal);
+      } else {
+        reveal();
+      }
+    };
+    pre.onerror = (): void => {
+      // keep the placeholder but drop the blur so we don't stay blurred forever
+      img.classList.add("loaded");
+    };
+    pre.src = src;
+  };
+
   if ("IntersectionObserver" in window) {
     const obs = new IntersectionObserver(
       (entries, o) => {
         entries.forEach((en) => {
           if (!en.isIntersecting) return;
           const img = en.target as HTMLImageElement;
-          const src = img.getAttribute("data-src");
-          if (src && img.src !== src) {
-            // trigger full-size load
-            img.src = src;
-          }
+          // preload full-size, then swap once ready (no blank frame)
+          loadFull(img);
           o.unobserve(img);
         });
       },

--- a/src/lib/lazy-images.ts
+++ b/src/lib/lazy-images.ts
@@ -12,7 +12,6 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
   const setPlaceholder = (img: HTMLImageElement): void => {
     const lqip = img.getAttribute("data-lqip");
     if (lqip) {
-      // only set when placeholder differs from current src
       if (!img.getAttribute("src") || img.getAttribute("src")?.[0] === "#") {
         img.src = lqip;
       }
@@ -20,13 +19,10 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
   };
 
   images.forEach((img) => {
-    // Skip if already handled
     if (img.dataset.lazyInitialized) return;
     img.dataset.lazyInitialized = "1";
 
-    // attach handlers BEFORE setting placeholder so we can react to subsequent loads
     const onLoad = (): void => {
-      // Only remove blur when the full-size image has loaded (or there is no data-src)
       const full = img.getAttribute("data-src");
       try {
         const currentSrc = img.currentSrc || img.src || "";
@@ -39,19 +35,15 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
     };
 
     const onError = (): void => {
-      // show placeholder even on error
       img.classList.add("loaded");
     };
 
     img.addEventListener("load", onLoad);
     img.addEventListener("error", onError);
 
-    // Prefer to have a tiny placeholder from data-lqip (do not clear blur)
     setPlaceholder(img);
 
-    // If already complete (cached), invoke handler to possibly set 'loaded'
     if (img.complete) {
-      // call onLoad or onError depending on whether naturalWidth is present
       if (img.naturalWidth && img.naturalWidth > 0) {
         onLoad();
       } else {
@@ -64,11 +56,8 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
     }
   });
 
-  // Preload the full-size image off-DOM and only swap the visible src once it
-  // is fully loaded (and decoded). Swapping src directly would discard the
-  // currently displayed LQIP and show a blank/white frame until the full image
-  // arrives — preloading keeps the blurred placeholder visible until the moment
-  // the sharp image is ready to paint.
+  // Preload off-DOM and swap the visible src only once the full image is ready,
+  // otherwise the browser drops the LQIP and shows a white frame mid-load.
   const loadFull = (img: HTMLImageElement): void => {
     const src = img.getAttribute("data-src");
     if (!src || img.src === src || img.dataset.fullLoaded) return;
@@ -81,7 +70,6 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
 
     const pre = new Image();
     pre.onload = (): void => {
-      // decode (when available) so the swap paints instantly without a flash
       if (typeof pre.decode === "function") {
         pre.decode().then(reveal).catch(reveal);
       } else {
@@ -89,7 +77,6 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
       }
     };
     pre.onerror = (): void => {
-      // keep the placeholder but drop the blur so we don't stay blurred forever
       img.classList.add("loaded");
     };
     pre.src = src;
@@ -101,7 +88,6 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
         entries.forEach((en) => {
           if (!en.isIntersecting) return;
           const img = en.target as HTMLImageElement;
-          // preload full-size, then swap once ready (no blank frame)
           loadFull(img);
           o.unobserve(img);
         });
@@ -110,11 +96,10 @@ export function initLazyImages(root?: Document | HTMLElement, observerRoot?: Ele
     );
 
     images.forEach((img) => {
-      if (img.classList.contains("loaded")) return; // already loaded
+      if (img.classList.contains("loaded")) return;
       obs.observe(img);
     });
   } else {
-    // fallback: eager load immediately
     images.forEach((img) => {
       const src = img.getAttribute("data-src");
       if (src && !img.classList.contains("loaded") && img.src !== src) {


### PR DESCRIPTION
## Summary

Two user-facing frontend fixes plus regression tests:

1. **Blur-up white flash** — lazy images flashed `blur → white → image`. Swapping `img.src` directly from the LQIP to the full-size source made the browser drop the displayed placeholder and paint a blank frame until the full image finished downloading.
2. **`a.target.closest is not a function` (Sentry cc23a20e)** — the drawer's `pointerenter`/`touchstart` capture handler cast `e.target` to `HTMLElement` and called `.closest()`. In the capture phase `e.target` can be `document`, `window`, or a text node, none of which have `closest()`, throwing an unhandled `TypeError`.

## Changes

### `fix(lazy-images)`: preload before swapping (`src/lib/lazy-images.ts`)
- Added `loadFull()` which preloads the full-size image off-DOM with a temporary `Image`, then swaps the visible `src` only once it is loaded (and decoded via `Image.decode()` when available).
- The blurred placeholder now stays visible until the sharp image can paint instantly — no blank frame.
- Guarded with a `data-fullLoaded` flag to avoid duplicate loads; the eager fallback path for browsers without `IntersectionObserver` is unchanged.

### `fix(drawer)`: guard `e.target` against non-Element (`src/lib/drawer.ts`)
- Added `if (!(e.target instanceof Element)) return;` before every `.closest()` call (prefetch, id-card click, drawer-link click) instead of an unchecked `as HTMLElement` cast.

### `test(drawer)`: new coverage (`src/__tests__/drawer.test.ts`)
- Regression cases for the non-Element `e.target` guard on both `pointerenter` and `click`.
- Open/close lifecycle (id-card click, drawer-link, Escape, backdrop), correct partial URLs, and hover-prefetch dedupe.

### `style(lazy-images)`: removed redundant inline comments

## Testing
- `tsc --noEmit` clean
- Full suite green: **92 tests** (was 84; +8 drawer tests)

https://claude.ai/code/session_01NhEssubueaDbTxtEL5nXVx