### PR TITLE
fix(brand-animation): resolve reverse-animation flicker and harden init

### DIFF
--- a/src/__tests__/brand-animation.test.ts
+++ b/src/__tests__/brand-animation.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initBrandAnimation } from "../lib/brand-animation";
 
-/** Stub matchMedia so tests can control prefers-reduced-motion. */
 function setReducedMotion(reduce: boolean): void {
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
     matches: reduce && query.includes("prefers-reduced-motion"),
@@ -30,9 +29,6 @@ describe("initBrandAnimation", () => {
   });
 
   it("should trigger reverse animation on homepage when returning from subpage", () => {
-    vi.useFakeTimers();
-
-    // Setup: brand-full element exists and brandAnimated flag is set
     document.body.innerHTML = '<div class="brand-full"></div>';
     sessionStorage.setItem("brandAnimated", "1");
 
@@ -40,21 +36,11 @@ describe("initBrandAnimation", () => {
 
     initBrandAnimation();
 
-    // Should have reverse-animated class
     expect(brandFull?.classList.contains("reverse-animated")).toBe(true);
-
-    // Session storage should be reset
     expect(sessionStorage.getItem("brandAnimated")).toBe("0");
-
-    // After the animation duration, the class should be removed
-    vi.advanceTimersByTime(800);
-    expect(brandFull?.classList.contains("reverse-animated")).toBe(false);
-
-    vi.useRealTimers();
   });
 
   it("should trigger forward animation on subpage when not yet animated", () => {
-    // Setup: brand-compact element exists and brandAnimated flag is not set
     document.body.innerHTML = '<div class="brand-compact"></div>';
     sessionStorage.removeItem("brandAnimated");
 
@@ -62,10 +48,7 @@ describe("initBrandAnimation", () => {
 
     initBrandAnimation();
 
-    // Should have animated class
     expect(brandCompact?.classList.contains("animated")).toBe(true);
-
-    // Session storage should be set
     expect(sessionStorage.getItem("brandAnimated")).toBe("1");
   });
 
@@ -77,7 +60,6 @@ describe("initBrandAnimation", () => {
 
     initBrandAnimation();
 
-    // Should not have animated class since already animated
     expect(brandCompact?.classList.contains("animated")).toBe(false);
   });
 
@@ -86,12 +68,11 @@ describe("initBrandAnimation", () => {
 
     initBrandAnimation();
 
-    // Flag should remain unchanged
     expect(sessionStorage.getItem("brandAnimated")).toBe("1");
   });
 
   describe("prefers-reduced-motion", () => {
-    it("should not add animation classes but still update the flag (forward)", () => {
+    it("should not add the forward class but still update the flag", () => {
       setReducedMotion(true);
       document.body.innerHTML = '<div class="brand-compact"></div>';
 
@@ -99,12 +80,11 @@ describe("initBrandAnimation", () => {
 
       initBrandAnimation();
 
-      // No animation class, but the state machine still advances
       expect(brandCompact?.classList.contains("animated")).toBe(false);
       expect(sessionStorage.getItem("brandAnimated")).toBe("1");
     });
 
-    it("should not add animation classes but still update the flag (reverse)", () => {
+    it("should not add the reverse class but still update the flag", () => {
       setReducedMotion(true);
       document.body.innerHTML = '<div class="brand-full"></div>';
       sessionStorage.setItem("brandAnimated", "1");
@@ -118,27 +98,19 @@ describe("initBrandAnimation", () => {
     });
   });
 
-  describe("unavailable sessionStorage", () => {
-    it("should not throw when sessionStorage access fails", () => {
-      document.body.innerHTML = '<div class="brand-compact"></div>';
+  it("should not throw when sessionStorage access fails", () => {
+    document.body.innerHTML = '<div class="brand-compact"></div>';
 
-      const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-        throw new DOMException("denied", "SecurityError");
-      });
-      const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
-        throw new DOMException("denied", "SecurityError");
-      });
-
-      // Must not throw, otherwise it would break the whole app init chain.
-      expect(() => initBrandAnimation()).not.toThrow();
-
-      // With storage unreadable we treat it as "not yet animated" and still
-      // play the forward animation.
-      const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
-      expect(brandCompact?.classList.contains("animated")).toBe(true);
-
-      getItemSpy.mockRestore();
-      setItemSpy.mockRestore();
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("denied", "SecurityError");
     });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("denied", "SecurityError");
+    });
+
+    expect(() => initBrandAnimation()).not.toThrow();
+
+    const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
+    expect(brandCompact?.classList.contains("animated")).toBe(true);
   });
 });

--- a/src/__tests__/brand-animation.test.ts
+++ b/src/__tests__/brand-animation.test.ts
@@ -1,13 +1,28 @@
 /**
  * Tests for brand-animation module
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initBrandAnimation } from "../lib/brand-animation";
+
+/** Stub matchMedia so tests can control prefers-reduced-motion. */
+function setReducedMotion(reduce: boolean): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: reduce && query.includes("prefers-reduced-motion"),
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
 
 describe("initBrandAnimation", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     sessionStorage.clear();
+    setReducedMotion(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should handle missing brand elements gracefully", () => {
@@ -31,7 +46,7 @@ describe("initBrandAnimation", () => {
     // Session storage should be reset
     expect(sessionStorage.getItem("brandAnimated")).toBe("0");
 
-    // After 800ms, class should be removed
+    // After the animation duration, the class should be removed
     vi.advanceTimersByTime(800);
     expect(brandFull?.classList.contains("reverse-animated")).toBe(false);
 
@@ -73,5 +88,57 @@ describe("initBrandAnimation", () => {
 
     // Flag should remain unchanged
     expect(sessionStorage.getItem("brandAnimated")).toBe("1");
+  });
+
+  describe("prefers-reduced-motion", () => {
+    it("should not add animation classes but still update the flag (forward)", () => {
+      setReducedMotion(true);
+      document.body.innerHTML = '<div class="brand-compact"></div>';
+
+      const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
+
+      initBrandAnimation();
+
+      // No animation class, but the state machine still advances
+      expect(brandCompact?.classList.contains("animated")).toBe(false);
+      expect(sessionStorage.getItem("brandAnimated")).toBe("1");
+    });
+
+    it("should not add animation classes but still update the flag (reverse)", () => {
+      setReducedMotion(true);
+      document.body.innerHTML = '<div class="brand-full"></div>';
+      sessionStorage.setItem("brandAnimated", "1");
+
+      const brandFull = document.querySelector<HTMLElement>(".brand-full");
+
+      initBrandAnimation();
+
+      expect(brandFull?.classList.contains("reverse-animated")).toBe(false);
+      expect(sessionStorage.getItem("brandAnimated")).toBe("0");
+    });
+  });
+
+  describe("unavailable sessionStorage", () => {
+    it("should not throw when sessionStorage access fails", () => {
+      document.body.innerHTML = '<div class="brand-compact"></div>';
+
+      const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+        throw new DOMException("denied", "SecurityError");
+      });
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new DOMException("denied", "SecurityError");
+      });
+
+      // Must not throw, otherwise it would break the whole app init chain.
+      expect(() => initBrandAnimation()).not.toThrow();
+
+      // With storage unreadable we treat it as "not yet animated" and still
+      // play the forward animation.
+      const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
+      expect(brandCompact?.classList.contains("animated")).toBe(true);
+
+      getItemSpy.mockRestore();
+      setItemSpy.mockRestore();
+    });
   });
 });

--- a/src/lib/brand-animation.ts
+++ b/src/lib/brand-animation.ts
@@ -1,33 +1,12 @@
 /**
  * Brand animation module
- *
- * The site header renders the brand title in two variants (see
- * `web/templates/components/header.html`):
- *  - `.brand-full`    on the homepage: full text, emojis de-emphasised (blurred)
- *  - `.brand-compact` on subpages:     text folded away, only the emojis remain
- *
- * On navigation we play a one-shot entrance animation that bridges the two
- * variants, driven entirely by CSS classes:
- *  - forward (home -> subpage): `.brand-compact.animated`     folds the text away
- *  - reverse (subpage -> home): `.brand-full.reverse-animated` unfolds the text
- *
- * A `sessionStorage` flag remembers whether the compact state has already been
- * shown, so the animation only plays on the relevant transition and not on
- * every page load.
+ * Plays the one-shot brand header animation on homepage <-> subpage navigation
  */
 
 const STORAGE_KEY = "brandAnimated";
 const COMPACT_SHOWN = "1";
 const COMPACT_HIDDEN = "0";
 
-/**
- * Duration after which the reverse-animation class is removed so the element
- * settles back into its plain resting state. Must be at least as long as the
- * longest reverse keyframe (`blurEmoji`, 0.8s in `web/static/style.css`).
- */
-const REVERSE_ANIMATION_MS = 800;
-
-/** Read the flag without throwing when storage is unavailable (private mode, etc.). */
 function readFlag(): string | null {
   try {
     return sessionStorage.getItem(STORAGE_KEY);
@@ -36,17 +15,14 @@ function readFlag(): string | null {
   }
 }
 
-/** Write the flag, silently ignoring storage failures. */
 function writeFlag(value: string): void {
   try {
     sessionStorage.setItem(STORAGE_KEY, value);
   } catch {
-    // Storage unavailable: the animation still plays, it just isn't
-    // remembered across navigations. Not worth breaking init over.
+    /* storage unavailable */
   }
 }
 
-/** Whether the user has asked the OS/browser to minimise motion. */
 function prefersReducedMotion(): boolean {
   return (
     typeof window.matchMedia === "function" &&
@@ -58,39 +34,20 @@ export function initBrandAnimation(): void {
   const brandFull = document.querySelector<HTMLElement>(".brand-full");
   const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
 
-  // No brand header on this page (e.g. error pages) - nothing to do.
-  if (!brandFull && !brandCompact) {
-    return;
-  }
+  if (!brandFull && !brandCompact) return;
 
   const flag = readFlag();
   const animate = !prefersReducedMotion();
 
-  // Homepage, returning from a subpage -> unfold the text back in.
+  // Homepage, returning from a subpage: unfold the text back in.
   if (brandFull && flag === COMPACT_SHOWN) {
     writeFlag(COMPACT_HIDDEN);
-    if (animate) {
-      playReverseAnimation(brandFull);
-    }
+    if (animate) brandFull.classList.add("reverse-animated");
   }
 
-  // Subpage, compact state not shown yet -> fold the text away.
+  // Subpage, compact state not shown yet: fold the text away.
   if (brandCompact && flag !== COMPACT_SHOWN) {
     writeFlag(COMPACT_SHOWN);
-    if (animate) {
-      brandCompact.classList.add("animated");
-    }
+    if (animate) brandCompact.classList.add("animated");
   }
-}
-
-/**
- * Plays the reverse (text unfold) animation on the full brand, then removes the
- * class once the animation has finished so the element returns to its plain
- * resting state (which is visually identical to the animation's end frame).
- */
-function playReverseAnimation(brandFull: HTMLElement): void {
-  brandFull.classList.add("reverse-animated");
-  window.setTimeout(() => {
-    brandFull.classList.remove("reverse-animated");
-  }, REVERSE_ANIMATION_MS);
 }

--- a/src/lib/brand-animation.ts
+++ b/src/lib/brand-animation.ts
@@ -1,26 +1,96 @@
 /**
  * Brand animation module
- * Handles brand animation logic on page transitions
+ *
+ * The site header renders the brand title in two variants (see
+ * `web/templates/components/header.html`):
+ *  - `.brand-full`    on the homepage: full text, emojis de-emphasised (blurred)
+ *  - `.brand-compact` on subpages:     text folded away, only the emojis remain
+ *
+ * On navigation we play a one-shot entrance animation that bridges the two
+ * variants, driven entirely by CSS classes:
+ *  - forward (home -> subpage): `.brand-compact.animated`     folds the text away
+ *  - reverse (subpage -> home): `.brand-full.reverse-animated` unfolds the text
+ *
+ * A `sessionStorage` flag remembers whether the compact state has already been
+ * shown, so the animation only plays on the relevant transition and not on
+ * every page load.
  */
+
+const STORAGE_KEY = "brandAnimated";
+const COMPACT_SHOWN = "1";
+const COMPACT_HIDDEN = "0";
+
+/**
+ * Duration after which the reverse-animation class is removed so the element
+ * settles back into its plain resting state. Must be at least as long as the
+ * longest reverse keyframe (`blurEmoji`, 0.8s in `web/static/style.css`).
+ */
+const REVERSE_ANIMATION_MS = 800;
+
+/** Read the flag without throwing when storage is unavailable (private mode, etc.). */
+function readFlag(): string | null {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Write the flag, silently ignoring storage failures. */
+function writeFlag(value: string): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Storage unavailable: the animation still plays, it just isn't
+    // remembered across navigations. Not worth breaking init over.
+  }
+}
+
+/** Whether the user has asked the OS/browser to minimise motion. */
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
 
 export function initBrandAnimation(): void {
   const brandFull = document.querySelector<HTMLElement>(".brand-full");
   const brandCompact = document.querySelector<HTMLElement>(".brand-compact");
 
-  // If on homepage and returning from a subpage, trigger reverse animation
-  if (brandFull && sessionStorage.getItem("brandAnimated") === "1") {
-    brandFull.classList.add("reverse-animated");
-    sessionStorage.setItem("brandAnimated", "0");
-
-    // Remove animation class after animation completes to restore normal state
-    setTimeout(() => {
-      brandFull.classList.remove("reverse-animated");
-    }, 800);
+  // No brand header on this page (e.g. error pages) - nothing to do.
+  if (!brandFull && !brandCompact) {
+    return;
   }
 
-  // If on subpage and not yet animated, trigger forward animation
-  if (brandCompact && sessionStorage.getItem("brandAnimated") !== "1") {
-    brandCompact.classList.add("animated");
-    sessionStorage.setItem("brandAnimated", "1");
+  const flag = readFlag();
+  const animate = !prefersReducedMotion();
+
+  // Homepage, returning from a subpage -> unfold the text back in.
+  if (brandFull && flag === COMPACT_SHOWN) {
+    writeFlag(COMPACT_HIDDEN);
+    if (animate) {
+      playReverseAnimation(brandFull);
+    }
   }
+
+  // Subpage, compact state not shown yet -> fold the text away.
+  if (brandCompact && flag !== COMPACT_SHOWN) {
+    writeFlag(COMPACT_SHOWN);
+    if (animate) {
+      brandCompact.classList.add("animated");
+    }
+  }
+}
+
+/**
+ * Plays the reverse (text unfold) animation on the full brand, then removes the
+ * class once the animation has finished so the element returns to its plain
+ * resting state (which is visually identical to the animation's end frame).
+ */
+function playReverseAnimation(brandFull: HTMLElement): void {
+  brandFull.classList.add("reverse-animated");
+  window.setTimeout(() => {
+    brandFull.classList.remove("reverse-animated");
+  }, REVERSE_ANIMATION_MS);
 }

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -224,10 +224,7 @@ main {
   animation: unblurEmoji 0.8s cubic-bezier(0.4, 0, 0.2, 1) 0.3s forwards;
 }
 
-/* Respect users who prefer reduced motion: drop the brand transitions/animations
-   and let the static resting states (full text / crisp emojis) stand in. The
-   JS in brand-animation.ts already skips adding the animation classes here, so
-   the brand simply renders in its correct end state without movement. */
+/* prefers-reduced-motion: fall back to the static resting states */
 @media (prefers-reduced-motion: reduce) {
   .brand-full .brand-emoji,
   .brand-compact .brand-emoji {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -169,7 +169,7 @@ main {
 }
 
 .brand-full.reverse-animated .brand-text {
-  display: inline-block !important;
+  display: inline-block;
   opacity: 0;
   transform: scaleX(0);
   transform-origin: left center;
@@ -222,6 +222,24 @@ main {
   filter: blur(4px);
   opacity: 0.8;
   animation: unblurEmoji 0.8s cubic-bezier(0.4, 0, 0.2, 1) 0.3s forwards;
+}
+
+/* Respect users who prefer reduced motion: drop the brand transitions/animations
+   and let the static resting states (full text / crisp emojis) stand in. The
+   JS in brand-animation.ts already skips adding the animation classes here, so
+   the brand simply renders in its correct end state without movement. */
+@media (prefers-reduced-motion: reduce) {
+  .brand-full .brand-emoji,
+  .brand-compact .brand-emoji {
+    transition: none;
+  }
+
+  .brand-full.reverse-animated .brand-text,
+  .brand-full.reverse-animated .brand-emoji,
+  .brand-compact.animated .brand-text,
+  .brand-compact.animated .brand-emoji {
+    animation: none;
+  }
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary

Fixes a flicker at the end of the brand header's reverse animation and hardens
the animation module against runtime failures and reduced-motion preferences.

## Fixes

- **Reverse-animation flicker**: On returning to the homepage, the
  `.reverse-animated` class was removed after an 800ms timeout, switching
  `.brand-text` from `inline-block` back to `inline`. That reflow shifted the
  emojis for a single frame (visible as a re-centering flicker, especially on
  mobile with `text-align: center`). The `forwards` animation already holds the
  correct resting state, so the class is now left in place and the timer dropped.
- **Storage resilience**: `sessionStorage` access is wrapped in `try/catch` so a
  `SecurityError` in private mode no longer throws out of `initBrandAnimation()`
  and aborts the rest of the app's init chain.
- **Accessibility**: Respect `prefers-reduced-motion` — animation classes are
  skipped (falling back to the correct static resting states) and a matching
  `@media (prefers-reduced-motion: reduce)` block neutralizes the CSS
  transitions/animations.

## Refactor

- Replace magic strings/numbers with named constants and add an early return when
  no brand header is present.
- Remove an unnecessary `!important` from a brand style rule.

## Tests

- Cover `prefers-reduced-motion` (forward + reverse) and unavailable
  `sessionStorage`; `matchMedia` is mocked per test.

https://claude.ai/code/session_0191oRU29LMgrJwLqDkBGGUd